### PR TITLE
support multiple datasets, uploading non-tabulr resources, dump log

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A processor to retrieve metadata about a CKAN resource from a CKAN instance and 
 
 ### `ckan.dump.to_ckan`
 
-A processor to save a datapackage and resources to a specified CKAN instance.
+A processor to save datapackages and resources to a specified CKAN instance.
 
 ```yaml
   run: ckan.dump.to_ckan
@@ -74,6 +74,13 @@ If the CKAN dataset was successfully created or updated, the dataset resources w
 
 Additionally, if `push_resources_to_datastore` is `True`, the processor will push resources marked for streaming to the CKAN DataStore using [`datastore_create`](https://ckan.readthedocs.io/en/latest/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_create) and [`datastore_upsert`](https://ckan.readthedocs.io/en/latest/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_upsert).
 
+Non streaming resources can also be uploaded, based on the value of `dpp:streamedFrom` resource attribute. If the
+value contains the path to a file, it will be uploaded to CKAN.
+
+If you need to use unicode or special characters in the resource name you can specify the name in
+the `dataset-resource-name` attribute which will be used for the created CKAN resource name rather
+then the default `name` attribute which is more limited by the schema.
+
 ##### Support for creating multiple datasets
 
 To create multiple datasets with variable properties, create additional (non tabular) resources in the datapackage for each
@@ -81,11 +88,13 @@ Dataset. The resource descriptor for these resources should contain the followin
 
 ```json
 {
+    "name": "ckan-dataset-1",
     "dataset-properties": {
         "name": "test-dataset-010203",
         "state": "draft",
         "owner_org": "my-org"
-    }
+    },
+    "data": {}
 }
 ```
 
@@ -100,3 +109,17 @@ The resources containing the data should have an additional attribute in their d
 ```
 
 This is used to relate each resource to the relevant dataset.
+
+##### Handling errors
+
+By default the dump.to_ckan processor raises Exceptions in case of errors. If instead you want to react on
+the action log and handle errors differently, set the `ckan-log-resource` parameter:
+
+```yaml
+  run: ckan.dump.to_ckan
+  parameters:
+    ckan-log-resource: ckan-log
+```
+
+Next processors in the pipeline will be able to process the `ckan-log` resource containing details of actions
+performed and errors encountered by the dump.to_ckan processor.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A processor to retrieve metadata about a CKAN resource from a CKAN instance and 
     ckan-api-key: env:CKAN_API_KEY  # an env var defining a ckan user api key
 ```
 
-- `ckan-host`: The base url (and scheme) for the CKAN instance (e.g. http://demo.ckan.org).
+- `ckan-host`: The base url (and scheme) for the CKAN instance (e.g. http://demo.ckan.org) or a value in the format `env:CKAN_HOST` that defines the host.
 - `resource-id`: The id of CKAN resource
 - `ckan-api-key`: Either a CKAN user api key or, if in the format `env:CKAN_API_KEY_NAME`, an env var that defines an api key. Optional, but necessary for private datasets.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A processor to save a datapackage and resources to a specified CKAN instance.
       owner_org: my-test-org
 ```
 
-- `ckan-host`: The base url (and scheme) for the CKAN instance (e.g. http://demo.ckan.org).
+- `ckan-host`: The base url (and scheme) for the CKAN instance (e.g. http://demo.ckan.org) or a value in the format `env:CKAN_HOST` that defines the host.
 - `ckan-api-key`: Either a CKAN user api key or, if in the format `env:CKAN_API_KEY_NAME`, an env var that defines an api key.
 - `overwrite_existing`: If `true`, if the CKAN dataset already exists, it will be overwritten by the datapackage. Optional, and default is `false`.
 - `push_resources_to_datastore`: If `true`, newly created resources will be pushed the CKAN DataStore. Optional, and default is `false`.
@@ -73,3 +73,30 @@ The processor first creates a CKAN dataset from the datapackage specification, u
 If the CKAN dataset was successfully created or updated, the dataset resources will be created for each resource in the datapackage, using [`resource_create`](http://docs.ckan.org/en/latest/api/#ckan.logic.action.create.resource_create). If datapackage resource are marked for streaming (they have the `dpp:streamed=True` property), resource files will be uploaded to the CKAN filestore. For example, remote resources may be marked for streaming by the inclusion of the `stream_remote_resources` processor earlier in the pipeline.
 
 Additionally, if `push_resources_to_datastore` is `True`, the processor will push resources marked for streaming to the CKAN DataStore using [`datastore_create`](https://ckan.readthedocs.io/en/latest/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_create) and [`datastore_upsert`](https://ckan.readthedocs.io/en/latest/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_upsert).
+
+##### Support for creating multiple datasets
+
+To create multiple datasets with variable properties, create additional (non tabular) resources in the datapackage for each
+Dataset. The resource descriptor for these resources should contain the following attributes:
+
+```json
+{
+    "dataset-properties": {
+        "name": "test-dataset-010203",
+        "state": "draft",
+        "owner_org": "my-org"
+    }
+}
+```
+
+The `name` attribute of dataset-properties is required, additional properties will override `dataset-properties` from the parameters.
+
+The resources containing the data should have an additional attribute in their descriptor to match to the relevant dataset:
+
+```json
+{
+    "dataset-name": "test-dataset-010203"
+}
+```
+
+This is used to relate each resource to the relevant dataset.

--- a/datapackage_pipelines_ckan/processors/add_ckan_resource.py
+++ b/datapackage_pipelines_ckan/processors/add_ckan_resource.py
@@ -6,7 +6,9 @@ from datapackage_pipelines.utilities.resources import (
 from datapackage_pipelines.generators import slugify
 from datapackage_pipelines.wrapper import ingest, spew
 
-from datapackage_pipelines_ckan.utils import make_ckan_request, get_ckan_error, get_env_param
+from datapackage_pipelines_ckan.utils import (
+    make_ckan_request, get_ckan_error, get_env_param
+)
 
 import logging
 log = logging.getLogger(__name__)
@@ -21,7 +23,8 @@ class AddCkanResource(object):
         self.resource_id = parameters.pop('resource-id')
 
     def get_resource_show_url(self):
-        return '{ckan_host}/api/3/action/resource_show'.format(ckan_host=self.ckan_host)
+        return '{ckan_host}/api/3/action/resource_show'.format(
+            ckan_host=self.ckan_host)
 
     def get_ckan_resource(self, resource_show_url):
         response = make_ckan_request(resource_show_url,
@@ -30,10 +33,13 @@ class AddCkanResource(object):
 
         ckan_error = get_ckan_error(response)
         if ckan_error:
-            if 'Not found: Resource was not found.' in ckan_error.get('message', []):
-                log.exception('CKAN resource {} was not found.'.format(self.resource_id))
+            if 'Not found: Resource ' \
+               'was not found.' in ckan_error.get('message', []):
+                log.exception('CKAN resource {} '
+                              'was not found.'.format(self.resource_id))
             else:
-                log.exception('CKAN returned an error: ' + json.dumps(ckan_error))
+                log.exception('CKAN returned an error: '
+                              '' + json.dumps(ckan_error))
 
             raise Exception
 

--- a/datapackage_pipelines_ckan/processors/add_ckan_resource.py
+++ b/datapackage_pipelines_ckan/processors/add_ckan_resource.py
@@ -6,14 +6,14 @@ from datapackage_pipelines.utilities.resources import (
 from datapackage_pipelines.generators import slugify
 from datapackage_pipelines.wrapper import ingest, spew
 
-from datapackage_pipelines_ckan.utils import make_ckan_request, get_ckan_error
+from datapackage_pipelines_ckan.utils import make_ckan_request, get_ckan_error, get_env_param
 
 import logging
 log = logging.getLogger(__name__)
 
 parameters, datapackage, res_iter = ingest()
 
-ckan_host = parameters.pop('ckan-host')
+ckan_host = get_env_param(parameters.pop('ckan-host'))
 ckan_api_key = parameters.pop('ckan-api-key', None)
 resource_id = parameters.pop('resource-id')
 resource_show_url = '{ckan_host}/api/3/action/resource_show'.format(

--- a/datapackage_pipelines_ckan/processors/add_ckan_resource.py
+++ b/datapackage_pipelines_ckan/processors/add_ckan_resource.py
@@ -73,5 +73,5 @@ class AddCkanResource(object):
         spew(datapackage, res_iter)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__' or spew.__class__.__name__ == 'MagicMock':
     AddCkanResource()()

--- a/datapackage_pipelines_ckan/processors/dump/to_ckan.py
+++ b/datapackage_pipelines_ckan/processors/dump/to_ckan.py
@@ -6,6 +6,8 @@ from tabulator import Stream
 import datapackage as datapackage_lib
 from ckan_datapackage_tools import converter
 from datapackage_pipelines.lib.dump.dumper_base import FileDumper, DumperBase
+from datapackage_pipelines.utilities.resources import is_a_url
+
 from tableschema_ckan_datastore import Storage
 
 from datapackage_pipelines_ckan.utils import make_ckan_request, get_ckan_error, get_env_param
@@ -24,6 +26,8 @@ class CkanDumper(FileDumper):
         self.__base_endpoint = self.__base_url + base_path
 
         self.__ckan_api_key = parameters.get('ckan-api-key')
+        self.__ckan_log_resource = parameters.get('ckan-log-resource')
+        self.__ckan_log = []
         self.__dataset_resources = []
         self.__dataset_id = None
         self.__dataset_ids = {}
@@ -36,6 +40,21 @@ class CkanDumper(FileDumper):
             raise RuntimeError(
                 'push_resources_to_datastore_method must be one of '
                 '\'insert\', \'upsert\' or \'update\'.')
+
+    def prepare_datapackage(self, datapackage, params):
+        datapackage = super(CkanDumper, self).prepare_datapackage(datapackage, params)
+        if self.__ckan_log_resource:
+            datapackage['resources'].append({'dpp:streaming': True,
+                                             'name': self.__ckan_log_resource,
+                                             'path': self.__ckan_log_resource + '.csv',
+                                             'schema': {'fields': [{'name': 'dataset_id', 'type': 'string'},
+                                                                   {'name': 'dataset_name', 'type': 'string'},
+                                                                   {'name': 'resource_id', 'type': 'string'},
+                                                                   {'name': 'resource_name', 'type': 'string'},
+                                                                   {'name': 'resource_url', 'type': 'string'},
+                                                                   {'name': 'resource_file', 'type': 'string'},
+                                                                   {'name': 'error', 'type': 'string'}]}})
+        return datapackage
 
     def get_resource_dataset_id(self, resource):
         if self.__dataset_id:
@@ -73,19 +92,31 @@ class CkanDumper(FileDumper):
         for resource in datapackage['resources']:
             if not resource.get('dpp:streaming', False):
                 dataset_id = self.get_resource_dataset_id(resource)
+                ckan_log_row = {'dataset_id': dataset_id, 'dataset_name': resource.get('dataset-name'),
+                                'resource_name': resource.get('name'),}
                 if dataset_id:
                     resource_metadata = {
                         'package_id': dataset_id,
-                        'url': resource['dpp:streamedFrom'],
-                        'name': resource['name'],
+                        'name': resource.get('dataset-resource-name', resource['name']),
                     }
                     if 'format' in resource:
                         resource_metadata.update({'format': resource['format']})
-                    request_params = {
-                        'json': resource_metadata
-                    }
-
-                    self._create_ckan_resource(request_params)
+                    streamed_from = resource['dpp:streamedFrom']
+                    if is_a_url(streamed_from):
+                        resource_metadata['url'] = streamed_from
+                        request_params = {
+                            'json': resource_metadata,
+                        }
+                        ckan_log_row.update(resource_file=None, resource_url=streamed_from)
+                    else:
+                        resource_metadata.update(url='url', url_type='upload')
+                        request_params = {'data': resource_metadata,
+                                          'files': {'upload': (streamed_from, open(streamed_from, 'rb'))}}
+                        ckan_log_row.update(resource_file=streamed_from, resource_url=None)
+                    self._create_ckan_resource(request_params, ckan_log_row)
+                else:
+                    self.__ckan_log.append(dict(ckan_log_row, resource_id=None, resource_url=None,
+                                                resource_file=None, error='no related dataset_id'))
 
         # Handle each resource in resource_iterator
         for resource in resource_iterator:
@@ -96,6 +127,9 @@ class CkanDumper(FileDumper):
                                        datapackage)
             ret = self.row_counter(datapackage, resource_spec, ret)
             yield ret
+
+        if self.__ckan_log_resource:
+            yield (row for row in self.__ckan_log)
 
         stats['count_of_rows'] = DumperBase.get_attr(datapackage,
                                                      self.datapackage_rowcount)
@@ -159,12 +193,20 @@ class CkanDumper(FileDumper):
                                          api_key=self.__ckan_api_key)
             ckan_error = get_ckan_error(response)
 
-        if ckan_error:
-            log.exception('CKAN returned an error: ' + json.dumps(ckan_error))
-            raise Exception
+        ckan_log_row = {'dataset_name': dataset['name'], 'resource_id': None, 'resource_name': None,
+                        'resource_url': None, 'resource_file': None}
 
-        return response['result']['id'] if response['success'] else None
+        if ckan_error or not response['success']:
+            self.__ckan_log.append(dict(ckan_log_row, dataset_id=None, error=json.dumps(ckan_error)))
+            if self.__ckan_log_resource:
+                return None
+            else:
+                log.exception('CKAN returned an error: ' + json.dumps(ckan_error))
+                raise Exception
 
+        dataset_id = response['result']['id']
+        self.__ckan_log.append(dict(ckan_log_row, dataset_id=dataset_id, error=None))
+        return dataset_id
 
     def handle_datapackage(self, datapackage, parameters, stats):
         '''Create or update ckan dataset/s from datapackage and parameters'''
@@ -206,6 +248,8 @@ class CkanDumper(FileDumper):
         temp_file.close()
 
         dataset_id = self.get_resource_dataset_id(spec)
+        ckan_log_row = {'dataset_id': dataset_id, 'dataset_name': spec.get('dataset-name'),
+                        'resource_name': spec.get('name'),}
         if dataset_id:
             resource_metadata = {
                 'package_id': dataset_id,
@@ -222,14 +266,15 @@ class CkanDumper(FileDumper):
             resource_files = {
                 'upload': (ckan_filename, open(temp_file.name, 'rb'))
             }
+            ckan_log_row.update(resource_url=None, resource_file=ckan_filename)
             request_params = {
                 'data': resource_metadata,
                 'files': resource_files
             }
             try:
                 # Create the CKAN resource
-                create_result = self._create_ckan_resource(request_params)
-                if self.__push_to_datastore:
+                create_result = self._create_ckan_resource(request_params, ckan_log_row)
+                if self.__push_to_datastore and create_result:
                     # Create the DataStore resource
                     storage = Storage(base_url=self.__base_url,
                                       dataset_id=dataset_id,
@@ -240,13 +285,18 @@ class CkanDumper(FileDumper):
                                   Stream(temp_file.name, format='csv').open(),
                                   method=self.__push_to_datastore_method)
             except Exception as e:
-                raise e
+                if self.__ckan_log_resource:
+                    self.__ckan_log.append(dict(ckan_log_row, resource_id=None, error=str(e)))
+                else:
+                    raise e
             finally:
                 os.unlink(filename)
         else:
+            self.__ckan_log.append(dict(ckan_log_row, resource_id=None, resource_url=None,
+                                        resource_file=None, error='no related dataset_id'))
             os.unlink(filename)
 
-    def _create_ckan_resource(self, request_params):
+    def _create_ckan_resource(self, request_params, ckan_log_row):
         resource_create_url = '{}/resource_create'.format(self.__base_endpoint)
 
         create_response = make_ckan_request(resource_create_url,
@@ -256,9 +306,16 @@ class CkanDumper(FileDumper):
 
         ckan_error = get_ckan_error(create_response)
         if ckan_error:
-            log.exception('CKAN returned an error when creating '
-                          'a resource: ' + json.dumps(ckan_error))
-            raise Exception
+            if self.__ckan_log_resource:
+                self.__ckan_log.append(dict(ckan_log_row, resource_id=None,
+                                            error=json.dumps(ckan_error)))
+                return None
+            else:
+                log.exception('CKAN returned an error when creating '
+                              'a resource: ' + json.dumps(ckan_error))
+                raise Exception
+
+        self.__ckan_log.append(dict(ckan_log_row, resource_id=create_response['result']['id'], error=None))
         return create_response['result']
 
 

--- a/datapackage_pipelines_ckan/utils.py
+++ b/datapackage_pipelines_ckan/utils.py
@@ -34,3 +34,10 @@ def get_ckan_error(response):
     if not response['success'] and response['error']:
         ckan_error = response['error']
     return ckan_error
+
+
+def get_env_param(value):
+    if value:
+        if value.startswith('env:'):
+            value = os.environ.get(value[4:])
+    return value

--- a/pylama.ini
+++ b/pylama.ini
@@ -3,3 +3,6 @@ linters = pyflakes,mccabe,pep8
 
 [pylama:*/__init__.py]
 ignore = W0611
+
+[pylama:datapackage_pipelines_ckan/processors/dump/to_ckan.py]
+ignore = C901

--- a/tests/test_dump_to_ckan.py
+++ b/tests/test_dump_to_ckan.py
@@ -609,7 +609,8 @@ class TestDumpToCkanProcessor(unittest.TestCase):
             'ckan-host': 'https://demo.ckan.org',
             'ckan-api-key': 'my-api-key',
             'overwrite_existing': True,
-            'force-format': True
+            'force-format': True,
+            'ckan-log-resource': 'ckan-log'
         }
 
         # Path to the processor we want to test


### PR DESCRIPTION
This PR contains several changes which I needed for [ckanext-upload_via_email](https://github.com/orihoch/ckanext-upload_via_email):
* Support loading multiple datasets, providing the dataset properties dynamically.
* Support for uploading non-tabular resources to CKAN (not just storing the URL)
* Output a resource with log of created datasets/resources or error details

Also some minor changes:
* Support setting the ckan host via env var
* Support for setting resource name with special chars
* Allow to extend the add_ckan_resource processor

I tried to keep backwards compatibility so existing pipelines shouldn't be affected by the changes

See updated docs and test for usage details.